### PR TITLE
dummy session api

### DIFF
--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import users, auth, items
+from app.api.v1.endpoints import users, auth, items, session
 
 api_router = APIRouter()
 
 api_router.include_router(auth.router, prefix="/auth", tags=["authentication"])
 api_router.include_router(users.router, prefix="/users", tags=["users"])
+api_router.include_router(session.router, prefix="/session", tags=["sessions"])
 # api_router.include_router(items.router, prefix="/items", tags=["items"]) 

--- a/backend/app/api/v1/endpoints/session.py
+++ b/backend/app/api/v1/endpoints/session.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session, joinedload
+from typing import List, Optional
+from app.core.database import get_db
+from app.models.organization import OrganizationMembership
+from app.models.user import User
+from app.schemas.session import SessionResponse
+
+router = APIRouter()
+
+@router.get("/", response_model=List[SessionResponse])
+async def get_sessions(
+    skip: int = 0,
+    limit: int = 100,
+    organization_id: Optional[int] = None,
+    user_id: Optional[int] = None,
+    db: Session = Depends(get_db),
+    # current_user: User = Depends(get_current_user)
+):
+    """Get organization-user combinations with related data."""
+    # If no parameters provided, return hardcoded first one
+    if organization_id is None and user_id is None:
+        query = db.query(OrganizationMembership).options(
+            joinedload(OrganizationMembership.organization),
+            joinedload(OrganizationMembership.user)
+        ).limit(1)
+        
+        membership = query.first()
+        
+        if membership is None:
+            return []
+        
+        return [{
+            "organization": membership.organization,
+            "user": membership.user,
+            "configuration": "configuration",
+            "version_of_software": "v0.1",
+            "session_info": "test session"
+        }]
+    
+    # If parameters provided, use normal filtering
+    query = db.query(OrganizationMembership).options(
+        joinedload(OrganizationMembership.organization),
+        joinedload(OrganizationMembership.user)
+    )
+    
+    if organization_id:
+        query = query.filter(OrganizationMembership.organization_id == organization_id)
+    if user_id:
+        query = query.filter(OrganizationMembership.user_id == user_id)
+    
+    memberships = query.offset(skip).limit(limit).all()
+    
+    return [
+        {
+            "organization": membership.organization,
+            "user": membership.user,
+            "configuration": None,
+            "version_of_software": None,
+            "session_info": None
+        }
+        for membership in memberships
+    ]

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class OrganizationInfo(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+    
+    class Config:
+        from_attributes = True
+
+class UserInfo(BaseModel):
+    id: int
+    email: str
+    first_name: str
+    last_name: Optional[str] = None
+    
+    class Config:
+        from_attributes = True
+
+class SessionResponse(BaseModel):
+    organization: OrganizationInfo
+    user: UserInfo
+    configuration: Optional[str] = None
+    version_of_software: Optional[str] = None
+    session_info: Optional[str] = None
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION

Implement dummy session API using User, Organization, and OrganizationMembership
- Query User, Organization, and OrganizationMembership tables
- Returns the first OrganizationMembership record
- Keep response objects separate to reflect underlying tables, so the API structure intentionally differs from the previous expectation

Note : when running locally for first time, run migrations and seed script to ensure db is populated